### PR TITLE
build: Fix 'incompatible pointer types' warning on i686

### DIFF
--- a/src/libpst.c
+++ b/src/libpst.c
@@ -3835,9 +3835,9 @@ static size_t pst_read_block_size(pst_file *pf, int64_t offset, size_t size, siz
         return -1;
     }
     *buf = (char *) pst_malloc(inflated_size);
-    size_t result_size = inflated_size;
-    if (uncompress((Bytef *) *buf, &result_size, (Bytef *) zbuf, size) != Z_OK || result_size != inflated_size) {
-        DEBUG_WARN(("Failed to uncompress %zu bytes to %zu bytes, got %zu\n", size, inflated_size, result_size));
+    uLongf result_size = inflated_size;
+    if (uncompress((Bytef *) *buf, &result_size, (Bytef *) zbuf, size) != Z_OK || ((size_t) result_size) != inflated_size) {
+        DEBUG_WARN(("Failed to uncompress %zu bytes to %zu bytes, got %zu\n", size, inflated_size, (size_t) result_size));
         if (zbuf) free(zbuf);
         DEBUG_RET();
         return -1;


### PR DESCRIPTION
This fixes a recent Fedora build, which failed on i686 architecture with "incompatible pointer types" error:

```
libpst.c: In function 'pst_read_block_size':
libpst.c:3832:36: error: passing argument 2 of 'uncompress' from incompatible pointer type [-Wincompatible-pointer-types]
 3832 |     if (uncompress((Bytef *) *buf, &result_size, (Bytef *) zbuf, size) != Z_OK || result_size != inflated_size) {
      |                                    ^~~~~~~~~~~~
      |                                    |
      |                                    size_t * {aka unsigned int *}
In file included from libpst.c:9:
/usr/include/zlib.h:1251:70: note: expected 'long unsigned int *' but argument is of type 'size_t *' {aka 'unsigned int *'}
 1251 | Z_EXTERN int Z_EXPORT uncompress(unsigned char *dest, unsigned long *destLen, const unsigned char *source, unsigned long sourceLen);
      |                                                       ~~~~~~~~~~~~~~~^~~~~~~
```